### PR TITLE
Add support for optional type annotations

### DIFF
--- a/parsonaut/lazy.py
+++ b/parsonaut/lazy.py
@@ -84,7 +84,7 @@ class Lazy(Generic[T, P], Serializable):
     @staticmethod
     def is_lazy_type(typ):
         origin = getattr(typ, "__origin__", None)
-        if origin is None and issubclass(typ, Lazy):
+        if origin is None and isinstance(typ, type) and issubclass(typ, Lazy):
             return True
         elif origin == Lazy:
             return True

--- a/parsonaut/parse.py
+++ b/parsonaut/parse.py
@@ -14,6 +14,7 @@ from parsonaut.typecheck import (
     is_flat_tuple_type,
     is_float_type,
     is_int_type,
+    is_optional_single_type,
     is_str_type,
 )
 
@@ -81,6 +82,8 @@ class ArgumentParser(_ArgumentParser):
         name = f"--{name}"
         check_val = value if value is not Missing else None
         required = False
+
+        _, typ = is_optional_single_type(typ, None)
 
         # bool
         if is_bool_type(typ):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -109,7 +109,7 @@ class Inner2(Parsable):
     def __init__(
         self,
         aa: str,
-        bb: int = 1,
+        bb: int | None = 1,
     ) -> None:
         pass
 

--- a/tests/test_typecheck.py
+++ b/tests/test_typecheck.py
@@ -1,4 +1,5 @@
 from itertools import combinations
+from typing import Optional, Union
 
 import pytest
 
@@ -9,6 +10,7 @@ from parsonaut.typecheck import (
     is_flat_tuple_type,
     is_float_type,
     is_int_type,
+    is_optional_single_type,
     is_parsable_type,
     is_str_type,
 )
@@ -130,3 +132,21 @@ def test_is_parsable_type_accepts(typ):
     assert is_parsable_type(tuple[typ])
     assert is_parsable_type(tuple[typ, typ])
     assert is_parsable_type(tuple[typ, ...])
+
+
+@pytest.mark.parametrize(
+    "typ, value, expected",
+    [
+        (int | None, None, (True, int)),
+        (int | None, 5, (True, int)),
+        (int | None, "hi", (False, int)),
+        (Optional[str], "hello", (True, str)),
+        (Optional[str], None, (True, str)),
+        (Optional[str], 123, (False, str)),
+        (int, 42, (False, int)),
+        (Union[int, str], "hello", (False, Union[int, str])),
+        (Union[int, None, str], None, (False, Union[int, None, str])),
+    ],
+)
+def test_is_optional_single_type(typ, value, expected):
+    assert is_optional_single_type(typ, value) == expected


### PR DESCRIPTION
Support annotations such as `int | None` or `Optional[int]` or `Union[int, None]`